### PR TITLE
fix: semester swap rule + settings auto-create + CI redis postinstall

### DIFF
--- a/packages/backend-graphql/src/resolvers/player/player.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/player/player.resolver.spec.ts
@@ -189,7 +189,7 @@ describe("PlayersResolver — setting ResolveField (auto-create)", () => {
     const created = { id: "settings-new", playerId: "player-1" } as unknown as Setting;
     const player = {
       id: "player-1",
-      sub: "auth0|6a66f1cc4c5f8ad111ba80ac", // real sub from production DB
+      sub: "auth0|test-claimed-player",
       getSetting: jest.fn().mockResolvedValue(null),
     } as unknown as Player;
 


### PR DESCRIPTION
## Summary

- **fix(change-encounter)**: Semester rule was blocking step 2 of a home/away encounter swap. When both encounters land temporarily in the same semester after step 1, the rule fired the current-state error before evaluating the proposed date. Fixed by gating the current-state check on absence of `suggestedDates`, and correcting the proposed-date conflict check to evaluate the proposed semester. Added `name` to home/away association attributes so `{teamName}` renders correctly in error messages.
- **fix(player)**: `@ResolveField setting` returned `null` for players who had logged in but had no settings row yet, blocking the notification settings form. Now auto-creates a default settings row on first read for players with an Auth0 `sub`. Federation-imported players (no `sub`) still return `null`.
- **ci(setup-monorepo)**: `ubuntu-latest` updated to Ubuntu 24.04, breaking `redis-memory-server` postinstall (compiles Redis from source). The binary is only needed for integration tests gated behind `RUN_INTEGRATION_TESTS=1` which never run in CI. Added `REDISMS_DISABLE_POSTINSTALL=1` to skip the compile step.

## Test plan

- [ ] `pnpm turbo run test --filter=@badman/backend-change-encounter` — `SemesterRule` spec (6 cases including exact production encounter De Voskes 1D ↔ W&L BV 3D)
- [ ] `pnpm turbo run test --filter=@badman/backend-graphql` — `PlayersResolver` setting ResolveField spec (3 cases)
- [ ] PR gate (`pull-request.yml`) passes — no redis postinstall compile failure
- [ ] Verify De Voskes 1D can now propose Jan 10 date in production