### PR TITLE
fix(change-encounter): enforce deadline on triage and finalize mutations

### DIFF
--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
@@ -192,6 +192,15 @@ describe("EncounterChangeCompetitionResolver", () => {
         resolver.triageEncounterChange(buildUser(false), input as any)
       ).rejects.toMatchObject({ extensions: { code: ErrorCode.DATE_OUT_OF_SEASON } });
     });
+
+    it("propagates DEADLINE_PASSED when module is closed", async () => {
+      mockEncounterChangeService.triage.mockRejectedValue(
+        new GraphQLError("deadline", { extensions: { code: ErrorCode.DEADLINE_PASSED } })
+      );
+      await expect(
+        resolver.triageEncounterChange(buildUser(true), input as any)
+      ).rejects.toMatchObject({ extensions: { code: ErrorCode.DEADLINE_PASSED } });
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -238,6 +247,15 @@ describe("EncounterChangeCompetitionResolver", () => {
       await expect(
         resolver.finalizeEncounterChange(buildUser(true), input as any)
       ).rejects.toMatchObject({ extensions: { code: ErrorCode.VALIDATION_FAILED } });
+    });
+
+    it("propagates DEADLINE_PASSED when module is closed", async () => {
+      mockEncounterChangeService.finalize.mockRejectedValue(
+        new GraphQLError("deadline", { extensions: { code: ErrorCode.DEADLINE_PASSED } })
+      );
+      await expect(
+        resolver.finalizeEncounterChange(buildUser(true), input as any)
+      ).rejects.toMatchObject({ extensions: { code: ErrorCode.DEADLINE_PASSED } });
     });
   });
 

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
@@ -88,15 +88,7 @@ export class EncounterChangeService {
 
     const event = await this._loadEvent(encounter);
 
-    if (event?.changeCloseRequestDatePeriod1 && event?.changeCloseRequestDatePeriod2) {
-      const closedDate = this._getDeadlineDate(encounter, event);
-      if (moment().isAfter(moment(closedDate))) {
-        this.logger.warn(`[propose] deadline passed encounterId=${encounter.id}`);
-        throw new GraphQLError("The deadline for requesting date changes has passed", {
-          extensions: { code: ErrorCode.DEADLINE_PASSED },
-        });
-      }
-    }
+    this._assertDeadlineNotPassed(encounter, event, "propose");
 
     const season = event?.season ?? new Date().getFullYear();
     for (const d of input.dates) {
@@ -232,6 +224,9 @@ export class EncounterChangeService {
     }
 
     const event = await this._loadEvent(encounter);
+
+    this._assertDeadlineNotPassed(encounter, event, "triage");
+
     const season = event?.season ?? new Date().getFullYear();
 
     for (const d of input.newDates ?? []) {
@@ -391,6 +386,9 @@ export class EncounterChangeService {
         { extensions: { code: ErrorCode.DATE_NOT_ENDORSED } }
       );
     }
+
+    const event = await this._loadEvent(encounter);
+    this._assertDeadlineNotPassed(encounter, event, "finalize");
 
     this.logger.debug(`[finalize] running validation for encounterId=${encounter.id}`);
     const validationResult = await this.encounterValidationService.validate({
@@ -552,6 +550,23 @@ export class EncounterChangeService {
       include: [{ model: SubEventCompetition, attributes: ["id", "eventId"] }],
     });
     return EventCompetition.findByPk(draw?.subEventCompetition?.eventId);
+  }
+
+  private _assertDeadlineNotPassed(
+    encounter: EncounterCompetition,
+    event: EventCompetition | null,
+    context: string
+  ): void {
+    if (!event?.changeCloseRequestDatePeriod1 || !event?.changeCloseRequestDatePeriod2) {
+      return;
+    }
+    const closedDate = this._getDeadlineDate(encounter, event);
+    if (moment().isAfter(moment(closedDate))) {
+      this.logger.warn(`[${context}] deadline passed encounterId=${encounter.id}`);
+      throw new GraphQLError("The deadline for requesting date changes has passed", {
+        extensions: { code: ErrorCode.DEADLINE_PASSED },
+      });
+    }
   }
 
   private _getDeadlineDate(

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
@@ -88,7 +88,7 @@ export class EncounterChangeService {
 
     const event = await this._loadEvent(encounter);
 
-    this._assertDeadlineNotPassed(encounter, event, "propose");
+    this._assertNewRequestDeadlineNotPassed(encounter, event, "propose");
 
     const season = event?.season ?? new Date().getFullYear();
     for (const d of input.dates) {
@@ -225,7 +225,12 @@ export class EncounterChangeService {
 
     const event = await this._loadEvent(encounter);
 
-    this._assertDeadlineNotPassed(encounter, event, "triage");
+    // Endorsing/rejecting existing dates is allowed until the accept window closes.
+    // Counter-proposing new dates is additionally gated by the new-request deadline.
+    this._assertAcceptDeadlineNotPassed(encounter, event, "triage");
+    if ((input.newDates ?? []).length > 0) {
+      this._assertNewRequestDeadlineNotPassed(encounter, event, "triage:counter-propose");
+    }
 
     const season = event?.season ?? new Date().getFullYear();
 
@@ -388,7 +393,7 @@ export class EncounterChangeService {
     }
 
     const event = await this._loadEvent(encounter);
-    this._assertDeadlineNotPassed(encounter, event, "finalize");
+    this._assertAcceptDeadlineNotPassed(encounter, event, "finalize");
 
     this.logger.debug(`[finalize] running validation for encounterId=${encounter.id}`);
     const validationResult = await this.encounterValidationService.validate({
@@ -552,7 +557,12 @@ export class EncounterChangeService {
     return EventCompetition.findByPk(draw?.subEventCompetition?.eventId);
   }
 
-  private _assertDeadlineNotPassed(
+  /**
+   * Throws DEADLINE_PASSED if the "new requests" window has closed
+   * (changeCloseRequestDatePeriod — "Sluit nieuwe aanvragen").
+   * Used for: propose, triage counter-proposals.
+   */
+  private _assertNewRequestDeadlineNotPassed(
     encounter: EncounterCompetition,
     event: EventCompetition | null,
     context: string
@@ -560,26 +570,45 @@ export class EncounterChangeService {
     if (!event?.changeCloseRequestDatePeriod1 || !event?.changeCloseRequestDatePeriod2) {
       return;
     }
-    const closedDate = this._getDeadlineDate(encounter, event);
+    const isSeason1 =
+      !!event.season &&
+      (encounter.date?.getFullYear() === event.season ||
+        encounter.date?.getFullYear() === event.season + 1);
+    const closedDate = isSeason1
+      ? event.changeCloseRequestDatePeriod1
+      : event.changeCloseRequestDatePeriod2;
     if (moment().isAfter(moment(closedDate))) {
-      this.logger.warn(`[${context}] deadline passed encounterId=${encounter.id}`);
+      this.logger.warn(`[${context}] new-request deadline passed encounterId=${encounter.id}`);
       throw new GraphQLError("The deadline for requesting date changes has passed", {
         extensions: { code: ErrorCode.DEADLINE_PASSED },
       });
     }
   }
 
-  private _getDeadlineDate(
+  /**
+   * Throws DEADLINE_PASSED if the "accept/finalize" window has closed
+   * (changeCloseDatePeriod — "Sluit aanvaarde aanvragen").
+   * Used for: triage (endorse/reject), finalize.
+   */
+  private _assertAcceptDeadlineNotPassed(
     encounter: EncounterCompetition,
-    event: EventCompetition
-  ): Date | undefined {
-    const matchesSeason =
-      event.season &&
+    event: EventCompetition | null,
+    context: string
+  ): void {
+    if (!event?.changeCloseDatePeriod1 || !event?.changeCloseDatePeriod2) {
+      return;
+    }
+    const isSeason1 =
+      !!event.season &&
       (encounter.date?.getFullYear() === event.season ||
         encounter.date?.getFullYear() === event.season + 1);
-    return matchesSeason
-      ? event.changeCloseRequestDatePeriod1
-      : event.changeCloseRequestDatePeriod2;
+    const closedDate = isSeason1 ? event.changeCloseDatePeriod1 : event.changeCloseDatePeriod2;
+    if (moment().isAfter(moment(closedDate))) {
+      this.logger.warn(`[${context}] accept deadline passed encounterId=${encounter.id}`);
+      throw new GraphQLError("The deadline for accepting date changes has passed", {
+        extensions: { code: ErrorCode.DEADLINE_PASSED },
+      });
+    }
   }
 
   private _isInCompetitionSeason(date: Date, season: number): boolean {


### PR DESCRIPTION
## Problem

The deadline check for the change-encounter module only existed on `propose`. This meant:

- Clubs could still access the module via notification links after the deadline (the frontend only greyed out the icon, not the direct URL)
- After the new-request deadline, the away team could still **triage with counter-proposals** (new dates), bypassing the deadline via the triage path
- The home team could still **finalize** a date change after the deadline

## Solution

Added backend enforcement to `triage` and `finalize` using the correct deadline field per action:

| Mutation | Gate | Field |
|---|---|---|
| `propose` | blocked after "Sluit nieuwe aanvragen" | `changeCloseRequestDatePeriod` |
| `triage` endorse/reject | blocked after "Sluit aanvaarde aanvragen" | `changeCloseDatePeriod` |
| `triage` counter-propose (`newDates`) | blocked after both deadlines | both |
| `finalize` | blocked after "Sluit aanvaarde aanvragen" | `changeCloseDatePeriod` |

Extracted the repeated check into two private helpers (`_assertNewRequestDeadlineNotPassed` / `_assertAcceptDeadlineNotPassed`) used across all three mutations.

## Test plan

- [ ] After `changeCloseRequestDate` passes: proposing new dates throws `DEADLINE_PASSED`
- [ ] After `changeCloseRequestDate` passes: triaging with `newDates` throws `DEADLINE_PASSED`
- [ ] After `changeCloseRequestDate` but before `changeCloseDate`: triaging with only endorse/reject IDs still works
- [ ] After `changeCloseDate` passes: triage endorse/reject and finalize both throw `DEADLINE_PASSED`
- [ ] All existing tests pass (`pnpm turbo run test --filter=@badman/backend-graphql`)