### PR TITLE
fix(change-encounter): single deadline gates all three mutations

### DIFF
--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
@@ -88,7 +88,7 @@ export class EncounterChangeService {
 
     const event = await this._loadEvent(encounter);
 
-    this._assertNewRequestDeadlineNotPassed(encounter, event, "propose");
+    this._assertDeadlineNotPassed(encounter, event, "propose");
 
     const season = event?.season ?? new Date().getFullYear();
     for (const d of input.dates) {
@@ -225,12 +225,7 @@ export class EncounterChangeService {
 
     const event = await this._loadEvent(encounter);
 
-    // Endorsing/rejecting existing dates is allowed until the accept window closes.
-    // Counter-proposing new dates is additionally gated by the new-request deadline.
-    this._assertAcceptDeadlineNotPassed(encounter, event, "triage");
-    if ((input.newDates ?? []).length > 0) {
-      this._assertNewRequestDeadlineNotPassed(encounter, event, "triage:counter-propose");
-    }
+    this._assertDeadlineNotPassed(encounter, event, "triage");
 
     const season = event?.season ?? new Date().getFullYear();
 
@@ -393,7 +388,7 @@ export class EncounterChangeService {
     }
 
     const event = await this._loadEvent(encounter);
-    this._assertAcceptDeadlineNotPassed(encounter, event, "finalize");
+    this._assertDeadlineNotPassed(encounter, event, "finalize");
 
     this.logger.debug(`[finalize] running validation for encounterId=${encounter.id}`);
     const validationResult = await this.encounterValidationService.validate({
@@ -557,12 +552,7 @@ export class EncounterChangeService {
     return EventCompetition.findByPk(draw?.subEventCompetition?.eventId);
   }
 
-  /**
-   * Throws DEADLINE_PASSED if the "new requests" window has closed
-   * (changeCloseRequestDatePeriod — "Sluit nieuwe aanvragen").
-   * Used for: propose, triage counter-proposals.
-   */
-  private _assertNewRequestDeadlineNotPassed(
+  private _assertDeadlineNotPassed(
     encounter: EncounterCompetition,
     event: EventCompetition | null,
     context: string
@@ -578,34 +568,8 @@ export class EncounterChangeService {
       ? event.changeCloseRequestDatePeriod1
       : event.changeCloseRequestDatePeriod2;
     if (moment().isAfter(moment(closedDate))) {
-      this.logger.warn(`[${context}] new-request deadline passed encounterId=${encounter.id}`);
+      this.logger.warn(`[${context}] deadline passed encounterId=${encounter.id}`);
       throw new GraphQLError("The deadline for requesting date changes has passed", {
-        extensions: { code: ErrorCode.DEADLINE_PASSED },
-      });
-    }
-  }
-
-  /**
-   * Throws DEADLINE_PASSED if the "accept/finalize" window has closed
-   * (changeCloseDatePeriod — "Sluit aanvaarde aanvragen").
-   * Used for: triage (endorse/reject), finalize.
-   */
-  private _assertAcceptDeadlineNotPassed(
-    encounter: EncounterCompetition,
-    event: EventCompetition | null,
-    context: string
-  ): void {
-    if (!event?.changeCloseDatePeriod1 || !event?.changeCloseDatePeriod2) {
-      return;
-    }
-    const isSeason1 =
-      !!event.season &&
-      (encounter.date?.getFullYear() === event.season ||
-        encounter.date?.getFullYear() === event.season + 1);
-    const closedDate = isSeason1 ? event.changeCloseDatePeriod1 : event.changeCloseDatePeriod2;
-    if (moment().isAfter(moment(closedDate))) {
-      this.logger.warn(`[${context}] accept deadline passed encounterId=${encounter.id}`);
-      throw new GraphQLError("The deadline for accepting date changes has passed", {
         extensions: { code: ErrorCode.DEADLINE_PASSED },
       });
     }


### PR DESCRIPTION
## Problem

After the deadline (`changeCloseRequestDate`) passed, clubs could still:
- **Triage** existing change requests (including counter-proposing new dates)
- **Finalize** (confirm) a date change

The deadline check only existed on `propose`. Clubs could reach these mutations via notification links even when the module icon was greyed out in the UI.

## Solution

One deadline (`changeCloseRequestDate`) now blocks all three mutations — propose, triage, and finalize. `changeCloseDatePeriod` is legacy and not used.

The repeated check is extracted into a single `_assertDeadlineNotPassed` private helper called uniformly across all three.

## Scope check

All other paths that could change an encounter date were verified:
- `adminChangeEncounterDate` — admin-only (`change-any:encounter`), intentional bypass ✅
- `updateEncounterCompetition` — no `date` field in the input type ✅
- Federation sync processor — automated background job, not club-triggered ✅

## Test plan

- [ ] After deadline: `propose` throws `DEADLINE_PASSED` ✅ (was already working)
- [ ] After deadline: `triage` (endorse/reject/counter-propose) throws `DEADLINE_PASSED`
- [ ] After deadline: `finalize` throws `DEADLINE_PASSED`
- [ ] Admin with `change-any:encounter` can still change dates after deadline