### PR TITLE
feat: expose queue introspection and harden the cron job resolver

### DIFF
--- a/database/migrations/20260910120000-add_change_job_claim.js
+++ b/database/migrations/20260910120000-add_change_job_claim.js
@@ -1,0 +1,57 @@
+"use strict";
+
+/**
+ * `change:job` gates every cronjob and queue operation (runCronJob, updateCronJob,
+ * the cronJobs query, the queue resolver and POST /queue-job). It predates
+ * migration-based claim seeding, so it exists only as a hand-inserted row on
+ * long-lived databases — a fresh database has no way to grant it.
+ *
+ * Insert is guarded on the name because existing databases already have this row
+ * (with their own id), and `Claims` is unique on (name, category). The category
+ * matches the value already used in production: "job".
+ */
+const claim = {
+  id: "c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
+  name: "change:job",
+  description: "Run and edit cron jobs, and inspect the queues",
+  category: "job",
+  type: "global",
+};
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      const [existing] = await queryInterface.sequelize.query(
+        `SELECT id FROM security."Claims" WHERE name = :name LIMIT 1`,
+        {
+          replacements: { name: claim.name },
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction: t,
+        }
+      );
+
+      if (existing) {
+        return;
+      }
+
+      await queryInterface.bulkInsert(
+        { tableName: "Claims", schema: "security" },
+        [{ ...claim, createdAt: new Date(), updatedAt: new Date() }],
+        { transaction: t }
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // Only remove the row this migration could have created. If the claim was
+      // already present under a different id, leave it alone.
+      await queryInterface.bulkDelete(
+        { tableName: "Claims", schema: "security" },
+        { id: { [Sequelize.Op.eq]: claim.id } },
+        { transaction: t }
+      );
+    });
+  },
+};

--- a/database/migrations/20260910120000-add_change_job_claim.js
+++ b/database/migrations/20260910120000-add_change_job_claim.js
@@ -11,7 +11,7 @@
  * matches the value already used in production: "job".
  */
 const claim = {
-  id: "c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
+  id: "f4b91170-ca0e-4c29-b5f6-b654ccaad00f",
   name: "change:job",
   description: "Run and edit cron jobs, and inspect the queues",
   category: "job",

--- a/docs/admin-permissions.md
+++ b/docs/admin-permissions.md
@@ -53,6 +53,7 @@ Known claim names as of 2026-06-08:
 | `add:faq`                         | global | Add FAQ entries                       |
 | `add:club`                        | global | Add a new club                        |
 | `change:enrollment`               | global | Open/close enrollment settings        |
+| `change:job`                      | global | Run/edit cron jobs, inspect queues    |
 | `change:rules`                    | global | Edit ranking rules                    |
 | `change:transfer`                 | global | Accept/reject player transfers        |
 | `edit:faq`                        | global | Edit FAQ content                      |

--- a/packages/backend-graphql/src/grapqhl.module.ts
+++ b/packages/backend-graphql/src/grapqhl.module.ts
@@ -32,6 +32,7 @@ import {
 import { CronJobResolverModule } from "./resolvers/cronJobs/cronJob.module";
 import { SettingResolverModule } from "./resolvers/setting/setting.module";
 import { ServiceResolverModule } from "./resolvers/services/serice.module";
+import { QueueResolverModule } from "./resolvers/queue/queue.module";
 
 @Module({
   imports: [
@@ -91,6 +92,7 @@ import { ServiceResolverModule } from "./resolvers/services/serice.module";
     NotificationResolverModule,
     ServiceResolverModule,
     CronJobResolverModule,
+    QueueResolverModule,
     SettingResolverModule,
   ],
   providers: [PlayerLoaderService],

--- a/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
@@ -8,7 +8,7 @@ import { CronJobResolver } from "./cronJob.resolver";
 describe("CronJobResolver", () => {
   let resolver: CronJobResolver;
   let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
-  let mockCronService: { onModuleInit: jest.Mock };
+  let mockCronService: { onModuleInit: jest.Mock; runJob: jest.Mock };
 
   const buildUser = (allowed: boolean) =>
     ({
@@ -18,7 +18,7 @@ describe("CronJobResolver", () => {
 
   beforeEach(async () => {
     mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
-    mockCronService = { onModuleInit: jest.fn() };
+    mockCronService = { onModuleInit: jest.fn(), runJob: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -43,7 +43,48 @@ describe("CronJobResolver", () => {
     it("returns list of cron jobs", async () => {
       const list = [{ id: "j1" }] as unknown as CronJob[];
       jest.spyOn(CronJob, "findAll").mockResolvedValue(list);
-      expect(await resolver.cronJobs({} as any)).toEqual(list);
+      expect(await resolver.cronJobs(buildUser(true), {} as any)).toEqual(list);
+    });
+
+    it("returns an empty list when there are no cron jobs", async () => {
+      jest.spyOn(CronJob, "findAll").mockResolvedValue([]);
+      expect(await resolver.cronJobs(buildUser(true), {} as any)).toEqual([]);
+    });
+
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      const findAll = jest.spyOn(CronJob, "findAll");
+      await expect(resolver.cronJobs(buildUser(false), {} as any)).rejects.toThrow(
+        UnauthorizedException
+      );
+      expect(findAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runCronJob (mutation)", () => {
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      const findByPk = jest.spyOn(CronJob, "findByPk");
+      await expect(resolver.runCronJob(buildUser(false), "j-uuid")).rejects.toThrow(
+        UnauthorizedException
+      );
+      expect(findByPk).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when cron job not found", async () => {
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(null);
+      await expect(resolver.runCronJob(buildUser(true), "missing")).rejects.toThrow(
+        NotFoundException
+      );
+      expect(mockCronService.runJob).not.toHaveBeenCalled();
+    });
+
+    it("hands the job to the cron service and returns it", async () => {
+      const fakeCronJob = { id: "j-uuid" } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+
+      const result = await resolver.runCronJob(buildUser(true), "j-uuid");
+
+      expect(mockCronService.runJob).toHaveBeenCalledWith(fakeCronJob);
+      expect(result).toBe(fakeCronJob);
     });
   });
 
@@ -72,6 +113,43 @@ describe("CronJobResolver", () => {
       expect(mockCronService.onModuleInit).toHaveBeenCalled();
       expect(mockTransaction.commit).toHaveBeenCalled();
       expect(result).toEqual({ id: "j-uuid" });
+    });
+
+    it("reinitializes the cron service only after the transaction commits", async () => {
+      const order: string[] = [];
+      mockTransaction.commit.mockImplementation(() => {
+        order.push("commit");
+      });
+      mockCronService.onModuleInit.mockImplementation(() => {
+        order.push("onModuleInit");
+      });
+
+      const fakeCronJob = {
+        update: jest.fn().mockResolvedValue({ id: "j-uuid" }),
+      } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+
+      await resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any);
+
+      expect(order).toEqual(["commit", "onModuleInit"]);
+    });
+
+    it("does not roll back a committed transaction when re-registering fails", async () => {
+      mockCronService.onModuleInit.mockImplementation(() => {
+        throw new Error("scheduler blew up");
+      });
+
+      const fakeCronJob = {
+        update: jest.fn().mockResolvedValue({ id: "j-uuid" }),
+      } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+
+      await expect(
+        resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any)
+      ).rejects.toThrow("scheduler blew up");
+
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
     });
 
     it("rolls back on error and does not commit", async () => {

--- a/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
@@ -146,7 +146,23 @@ describe("CronJobResolver", () => {
 
       await expect(
         resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any)
-      ).rejects.toThrow("scheduler blew up");
+      ).resolves.toEqual({ id: "j-uuid" });
+
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    });
+
+    it("swallows an async re-registration failure instead of leaking a rejection", async () => {
+      mockCronService.onModuleInit.mockRejectedValue(new Error("scheduler blew up later"));
+
+      const fakeCronJob = {
+        update: jest.fn().mockResolvedValue({ id: "j-uuid" }),
+      } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+
+      await expect(
+        resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any)
+      ).resolves.toEqual({ id: "j-uuid" });
 
       expect(mockTransaction.commit).toHaveBeenCalled();
       expect(mockTransaction.rollback).not.toHaveBeenCalled();

--- a/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.ts
@@ -88,8 +88,18 @@ export class CronJobResolver {
     // Reinitialize the cron jobs. This re-reads the CronJobs table, so it has to run
     // after the commit — otherwise it re-registers the pre-update schedule. It is
     // deliberately outside the try/catch: the write is already durable, so a failure
-    // to re-register must not roll back a committed transaction.
-    this._cronsService.onModuleInit();
+    // to re-register must not roll back a committed transaction. It is async and
+    // deletes every registered cron before re-adding them, so a rejection must be
+    // caught here — an unhandled rejection would take the process down and leave the
+    // scheduler empty.
+    try {
+      await this._cronsService.onModuleInit();
+    } catch (error) {
+      this.logger.error(
+        `Failed to re-register cron jobs after updating ${updateCronJobData.id}`,
+        error
+      );
+    }
 
     return result;
   }

--- a/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/cronJobs/cronJob.resolver.ts
@@ -23,7 +23,11 @@ export class CronJobResolver {
   ) {}
 
   @Query(() => [CronJob])
-  async cronJobs(@Args() listArgs: ListArgs): Promise<CronJob[]> {
+  async cronJobs(@User() user: Player, @Args() listArgs: ListArgs): Promise<CronJob[]> {
+    if (!(await user.hasAnyPermission(["change:job"]))) {
+      throw new UnauthorizedException(`You do not have permission to view the CronJobs`);
+    }
+
     return CronJob.findAll(ListArgs.toFindOptions(listArgs));
   }
 
@@ -61,6 +65,8 @@ export class CronJobResolver {
 
     // Do transaction
     const transaction = await this._sequelize.transaction();
+    let result: CronJob;
+
     try {
       const cronJobDb = await CronJob.findByPk(updateCronJobData.id, { transaction });
 
@@ -69,20 +75,23 @@ export class CronJobResolver {
       }
 
       // Update CronJob
-      const result = await cronJobDb.update(updateCronJobData, { transaction });
-
-      // Reinitialize the cron jobs
-      this._cronsService.onModuleInit();
+      result = await cronJobDb.update(updateCronJobData, { transaction });
 
       // Commit transaction
       await transaction.commit();
-
-      return result;
     } catch (error) {
       this.logger.error(error);
       await transaction.rollback();
       throw error;
     }
+
+    // Reinitialize the cron jobs. This re-reads the CronJobs table, so it has to run
+    // after the commit — otherwise it re-registers the pre-update schedule. It is
+    // deliberately outside the try/catch: the write is already durable, so a failure
+    // to re-register must not roll back a committed transaction.
+    this._cronsService.onModuleInit();
+
+    return result;
   }
 }
 

--- a/packages/backend-graphql/src/resolvers/queue/queue.module.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.module.ts
@@ -1,0 +1,10 @@
+import { DatabaseModule } from "@badman/backend-database";
+import { QueueModule } from "@badman/backend-queue";
+import { Module } from "@nestjs/common";
+import { QueueResolver } from "./queue.resolver";
+
+@Module({
+  imports: [DatabaseModule, QueueModule],
+  providers: [QueueResolver],
+})
+export class QueueResolverModule {}

--- a/packages/backend-graphql/src/resolvers/queue/queue.object.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.object.ts
@@ -1,0 +1,68 @@
+import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
+
+/**
+ * Live Bull/Redis counters for a single queue.
+ *
+ * These are not persisted anywhere: they are read straight from Redis on every
+ * request, so two calls a second apart can legitimately disagree.
+ */
+@ObjectType()
+export class QueueStats {
+  @Field(() => String)
+  declare name: string;
+
+  @Field(() => Int)
+  declare waiting: number;
+
+  @Field(() => Int)
+  declare active: number;
+
+  @Field(() => Int)
+  declare completed: number;
+
+  @Field(() => Int)
+  declare failed: number;
+
+  @Field(() => Int)
+  declare delayed: number;
+}
+
+/**
+ * A single Bull job, flattened for transport.
+ *
+ * Bull keeps only a small window of finished jobs (see `removeOnComplete` /
+ * `removeOnFail` in `@badman/backend-queue`), so this is a live view, not a history.
+ */
+@ObjectType()
+export class QueueJob {
+  @Field(() => ID)
+  declare id: string;
+
+  @Field(() => String)
+  declare queue: string;
+
+  @Field(() => String)
+  declare name: string;
+
+  @Field(() => String)
+  declare state: string;
+
+  /** `job.data`, JSON-stringified — the shape differs per job name. */
+  @Field(() => String, { nullable: true })
+  declare data?: string;
+
+  @Field(() => String, { nullable: true })
+  declare failedReason?: string;
+
+  @Field(() => Int)
+  declare attemptsMade: number;
+
+  @Field(() => Int)
+  declare attemptsTotal: number;
+
+  @Field(() => Date, { nullable: true })
+  declare processedOn?: Date;
+
+  @Field(() => Date, { nullable: true })
+  declare finishedOn?: Date;
+}

--- a/packages/backend-graphql/src/resolvers/queue/queue.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.resolver.spec.ts
@@ -1,0 +1,229 @@
+import { Player } from "@badman/backend-database";
+import { RankingQueue, SyncQueue } from "@badman/backend-queue";
+import { getQueueToken } from "@nestjs/bull";
+import { UnauthorizedException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { GraphQLError } from "graphql";
+import { ErrorCode } from "../../utils/error-codes";
+import { QueueResolver } from "./queue.resolver";
+
+type MockQueue = {
+  getWaitingCount: jest.Mock;
+  getActiveCount: jest.Mock;
+  getCompletedCount: jest.Mock;
+  getFailedCount: jest.Mock;
+  getDelayedCount: jest.Mock;
+  getFailed: jest.Mock;
+  getActive: jest.Mock;
+  getWaiting: jest.Mock;
+  getJob: jest.Mock;
+};
+
+const buildQueue = (counts = 0): MockQueue => ({
+  getWaitingCount: jest.fn().mockResolvedValue(counts),
+  getActiveCount: jest.fn().mockResolvedValue(counts),
+  getCompletedCount: jest.fn().mockResolvedValue(counts),
+  getFailedCount: jest.fn().mockResolvedValue(counts),
+  getDelayedCount: jest.fn().mockResolvedValue(counts),
+  getFailed: jest.fn().mockResolvedValue([]),
+  getActive: jest.fn().mockResolvedValue([]),
+  getWaiting: jest.fn().mockResolvedValue([]),
+  getJob: jest.fn().mockResolvedValue(null),
+});
+
+const buildUser = (allowed: boolean) =>
+  ({
+    id: "user-uuid",
+    hasAnyPermission: jest.fn().mockResolvedValue(allowed),
+  }) as unknown as Player;
+
+describe("QueueResolver", () => {
+  let resolver: QueueResolver;
+  let syncQueue: MockQueue;
+  let rankingQueue: MockQueue;
+
+  beforeEach(async () => {
+    syncQueue = buildQueue(1);
+    rankingQueue = buildQueue(2);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueResolver,
+        { provide: getQueueToken(SyncQueue), useValue: syncQueue },
+        { provide: getQueueToken(RankingQueue), useValue: rankingQueue },
+      ],
+    }).compile();
+
+    resolver = module.get<QueueResolver>(QueueResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("queueStats (query)", () => {
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      await expect(resolver.queueStats(buildUser(false))).rejects.toThrow(UnauthorizedException);
+      expect(syncQueue.getWaitingCount).not.toHaveBeenCalled();
+    });
+
+    it("aggregates counters for both queues", async () => {
+      const result = await resolver.queueStats(buildUser(true));
+
+      expect(result).toEqual([
+        { name: "sync", waiting: 1, active: 1, completed: 1, failed: 1, delayed: 1 },
+        { name: "ranking", waiting: 2, active: 2, completed: 2, failed: 2, delayed: 2 },
+      ]);
+    });
+  });
+
+  describe("queueJobs (query)", () => {
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      await expect(resolver.queueJobs(buildUser(false), "sync", "failed", 50)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("maps bull jobs onto the transport shape", async () => {
+      syncQueue.getFailed.mockResolvedValue([
+        {
+          id: 42,
+          name: "SyncEvents",
+          data: { id: "abc" },
+          failedReason: "boom",
+          attemptsMade: 2,
+          opts: { attempts: 3 },
+          processedOn: 1_700_000_000_000,
+          finishedOn: 1_700_000_060_000,
+        },
+      ]);
+
+      const [job] = await resolver.queueJobs(buildUser(true), "sync", "failed", 50);
+
+      expect(job).toEqual({
+        id: "42",
+        queue: "sync",
+        name: "SyncEvents",
+        state: "failed",
+        data: JSON.stringify({ id: "abc" }),
+        failedReason: "boom",
+        attemptsMade: 2,
+        attemptsTotal: 3,
+        processedOn: new Date(1_700_000_000_000),
+        finishedOn: new Date(1_700_000_060_000),
+      });
+    });
+
+    it("defaults attemptsTotal to 1 when the job carries no attempts option", async () => {
+      syncQueue.getWaiting.mockResolvedValue([{ id: 1, name: "SyncEvents", opts: {} }]);
+
+      const [job] = await resolver.queueJobs(buildUser(true), "sync", "waiting", 50);
+
+      expect(job.attemptsTotal).toBe(1);
+      expect(job.attemptsMade).toBe(0);
+    });
+
+    it("converts limit into an inclusive bull range and caps it", async () => {
+      await resolver.queueJobs(buildUser(true), "sync", "active", 10);
+      expect(syncQueue.getActive).toHaveBeenCalledWith(0, 9);
+
+      await resolver.queueJobs(buildUser(true), "sync", "active", 5000);
+      expect(syncQueue.getActive).toHaveBeenLastCalledWith(0, 199);
+    });
+
+    it("rejects an unknown queue with BAD_USER_INPUT", async () => {
+      expect.assertions(2);
+      try {
+        await resolver.queueJobs(buildUser(true), "nope", "failed", 50);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+      }
+    });
+
+    it("rejects an unknown state with BAD_USER_INPUT", async () => {
+      expect.assertions(2);
+      try {
+        await resolver.queueJobs(buildUser(true), "sync", "completed", 50);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+      }
+    });
+  });
+
+  describe("retryQueueJob (mutation)", () => {
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      await expect(resolver.retryQueueJob(buildUser(false), "sync", "1")).rejects.toThrow(
+        UnauthorizedException
+      );
+      expect(syncQueue.getJob).not.toHaveBeenCalled();
+    });
+
+    it("rejects a job that no longer exists with QUEUE_JOB_NOT_FOUND", async () => {
+      syncQueue.getJob.mockResolvedValue(null);
+
+      expect.assertions(2);
+      try {
+        await resolver.retryQueueJob(buildUser(true), "sync", "missing");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).extensions.code).toBe(ErrorCode.QUEUE_JOB_NOT_FOUND);
+      }
+    });
+
+    it("rejects a job that is not failed with INVALID_STATE", async () => {
+      const retry = jest.fn();
+      syncQueue.getJob.mockResolvedValue({
+        id: 7,
+        name: "SyncEvents",
+        opts: {},
+        getState: jest.fn().mockResolvedValue("active"),
+        retry,
+      });
+
+      expect.assertions(3);
+      try {
+        await resolver.retryQueueJob(buildUser(true), "sync", "7");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).extensions.code).toBe(ErrorCode.INVALID_STATE);
+      }
+      expect(retry).not.toHaveBeenCalled();
+    });
+
+    it("retries a failed job and reports it as waiting", async () => {
+      const retry = jest.fn().mockResolvedValue(undefined);
+      syncQueue.getJob.mockResolvedValue({
+        id: 7,
+        name: "SyncEvents",
+        data: { id: "abc" },
+        failedReason: "boom",
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+        getState: jest.fn().mockResolvedValue("failed"),
+        retry,
+      });
+
+      const result = await resolver.retryQueueJob(buildUser(true), "sync", "7");
+
+      expect(retry).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe("7");
+      expect(result.state).toBe("waiting");
+      expect(result.queue).toBe("sync");
+    });
+
+    it("resolves the job from the queue that was named", async () => {
+      rankingQueue.getJob.mockResolvedValue({
+        id: 9,
+        name: "UpdateRanking",
+        opts: {},
+        getState: jest.fn().mockResolvedValue("failed"),
+        retry: jest.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await resolver.retryQueueJob(buildUser(true), "ranking", "9");
+
+      expect(result.queue).toBe("ranking");
+      expect(syncQueue.getJob).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend-graphql/src/resolvers/queue/queue.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.resolver.spec.ts
@@ -129,6 +129,16 @@ describe("QueueResolver", () => {
       expect(syncQueue.getActive).toHaveBeenLastCalledWith(0, 199);
     });
 
+    it("returns nothing for a non-positive or missing limit", async () => {
+      for (const limit of [0, -1, null, undefined]) {
+        await expect(
+          resolver.queueJobs(buildUser(true), "sync", "active", limit as number)
+        ).resolves.toEqual([]);
+      }
+
+      expect(syncQueue.getActive).not.toHaveBeenCalled();
+    });
+
     it("rejects an unknown queue with BAD_USER_INPUT", async () => {
       expect.assertions(2);
       try {

--- a/packages/backend-graphql/src/resolvers/queue/queue.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.resolver.ts
@@ -43,8 +43,15 @@ export class QueueResolver {
 
     const queue = this._getQueue(queueName);
     const listableState = this._getState(state);
+
+    // An explicit `null` bypasses the default, and a client can pass 0 or a negative
+    // number. Bull's range is inclusive, so clamping to 0 would still return one job.
+    if (limit == null || limit <= 0) {
+      return [];
+    }
+
     // Bull's range is inclusive on both ends, so `limit` items means `limit - 1`.
-    const end = Math.max(0, Math.min(limit, 200) - 1);
+    const end = Math.min(limit, 200) - 1;
 
     const jobs = await this._fetchJobs(queue, listableState, end);
     return jobs.map((job) => this._toQueueJob(job, queueName, listableState));

--- a/packages/backend-graphql/src/resolvers/queue/queue.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/queue/queue.resolver.ts
@@ -1,0 +1,163 @@
+import { User } from "@badman/backend-authorization";
+import { Player } from "@badman/backend-database";
+import { RankingQueue, SyncQueue } from "@badman/backend-queue";
+import { InjectQueue } from "@nestjs/bull";
+import { Logger, UnauthorizedException } from "@nestjs/common";
+import { Args, ID, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Job, Queue } from "bull";
+import { GraphQLError } from "graphql";
+import { ErrorCode } from "../../utils/error-codes";
+import { QueueJob, QueueStats } from "./queue.object";
+
+/** Permission required for every operation on this resolver. */
+const QUEUE_PERMISSION = "change:job";
+
+/** The states a job can be listed by. Bull knows more, these are the useful ones. */
+const LISTABLE_STATES = ["waiting", "active", "failed"] as const;
+type ListableState = (typeof LISTABLE_STATES)[number];
+
+@Resolver(() => QueueJob)
+export class QueueResolver {
+  private readonly logger = new Logger(QueueResolver.name);
+
+  constructor(
+    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue,
+    @InjectQueue(RankingQueue) private readonly _rankingQueue: Queue
+  ) {}
+
+  @Query(() => [QueueStats])
+  async queueStats(@User() user: Player): Promise<QueueStats[]> {
+    await this._assertPermission(user);
+
+    return Promise.all(this._allQueues().map(([name, queue]) => this._statsFor(name, queue)));
+  }
+
+  @Query(() => [QueueJob])
+  async queueJobs(
+    @User() user: Player,
+    @Args("queue", { type: () => String }) queueName: string,
+    @Args("state", { type: () => String }) state: string,
+    @Args("limit", { type: () => Int, nullable: true, defaultValue: 50 }) limit: number
+  ): Promise<QueueJob[]> {
+    await this._assertPermission(user);
+
+    const queue = this._getQueue(queueName);
+    const listableState = this._getState(state);
+    // Bull's range is inclusive on both ends, so `limit` items means `limit - 1`.
+    const end = Math.max(0, Math.min(limit, 200) - 1);
+
+    const jobs = await this._fetchJobs(queue, listableState, end);
+    return jobs.map((job) => this._toQueueJob(job, queueName, listableState));
+  }
+
+  @Mutation(() => QueueJob)
+  async retryQueueJob(
+    @User() user: Player,
+    @Args("queue", { type: () => String }) queueName: string,
+    @Args("id", { type: () => ID }) id: string
+  ): Promise<QueueJob> {
+    await this._assertPermission(user);
+
+    const queue = this._getQueue(queueName);
+    const job = await queue.getJob(id);
+
+    if (!job) {
+      // Bull evicts finished jobs on a small window (removeOnComplete / removeOnFail),
+      // so a job disappearing is routine rather than exceptional. Give clients a code
+      // they can distinguish from a genuine failure.
+      throw new GraphQLError(`Job ${id} not found in queue ${queueName}`, {
+        extensions: { code: ErrorCode.QUEUE_JOB_NOT_FOUND, jobId: id, queue: queueName },
+      });
+    }
+
+    const state = await job.getState();
+    if (state !== "failed") {
+      throw new GraphQLError(`Job ${id} is in state '${state}', only failed jobs can be retried`, {
+        extensions: { code: ErrorCode.INVALID_STATE, jobId: id, queue: queueName, state },
+      });
+    }
+
+    await job.retry();
+    this.logger.log(`Retried job ${id} (${job.name}) on queue ${queueName}`);
+
+    // `job.retry()` moves it back to waiting; report the state it lands in rather
+    // than re-reading, which would race with a worker picking it straight up.
+    return this._toQueueJob(job, queueName, "waiting");
+  }
+
+  private async _assertPermission(user: Player): Promise<void> {
+    if (!(await user.hasAnyPermission([QUEUE_PERMISSION]))) {
+      throw new UnauthorizedException(`You do not have permission to inspect the queues`);
+    }
+  }
+
+  private _allQueues(): [string, Queue][] {
+    return [
+      [SyncQueue, this._syncQueue],
+      [RankingQueue, this._rankingQueue],
+    ];
+  }
+
+  private _getQueue(name: string): Queue {
+    const match = this._allQueues().find(([queueName]) => queueName === name);
+
+    if (!match) {
+      throw new GraphQLError(`Unknown queue '${name}'`, {
+        extensions: {
+          code: ErrorCode.BAD_USER_INPUT,
+          allowed: this._allQueues().map(([queueName]) => queueName),
+        },
+      });
+    }
+
+    return match[1];
+  }
+
+  private _getState(state: string): ListableState {
+    if (!LISTABLE_STATES.includes(state as ListableState)) {
+      throw new GraphQLError(`Unknown job state '${state}'`, {
+        extensions: { code: ErrorCode.BAD_USER_INPUT, allowed: [...LISTABLE_STATES] },
+      });
+    }
+
+    return state as ListableState;
+  }
+
+  private _fetchJobs(queue: Queue, state: ListableState, end: number): Promise<Job[]> {
+    switch (state) {
+      case "failed":
+        return queue.getFailed(0, end);
+      case "active":
+        return queue.getActive(0, end);
+      case "waiting":
+        return queue.getWaiting(0, end);
+    }
+  }
+
+  private async _statsFor(name: string, queue: Queue): Promise<QueueStats> {
+    const [waiting, active, completed, failed, delayed] = await Promise.all([
+      queue.getWaitingCount(),
+      queue.getActiveCount(),
+      queue.getCompletedCount(),
+      queue.getFailedCount(),
+      queue.getDelayedCount(),
+    ]);
+
+    return { name, waiting, active, completed, failed, delayed };
+  }
+
+  private _toQueueJob(job: Job, queueName: string, state: string): QueueJob {
+    return {
+      id: `${job.id}`,
+      queue: queueName,
+      name: job.name,
+      state,
+      data: job.data === undefined ? undefined : JSON.stringify(job.data),
+      failedReason: job.failedReason ?? undefined,
+      attemptsMade: job.attemptsMade ?? 0,
+      attemptsTotal: job.opts?.attempts ?? 1,
+      processedOn: job.processedOn ? new Date(job.processedOn) : undefined,
+      finishedOn: job.finishedOn ? new Date(job.finishedOn) : undefined,
+    };
+  }
+}

--- a/packages/backend-graphql/src/utils/error-codes.ts
+++ b/packages/backend-graphql/src/utils/error-codes.ts
@@ -40,6 +40,9 @@ export const ErrorCode = {
   ENROLLMENT_CLOSED: "ENROLLMENT_CLOSED",
   VALIDATION_FAILED: "VALIDATION_FAILED",
 
+  // Queue introspection (packages/backend-graphql/src/resolvers/queue/queue.resolver.ts)
+  QUEUE_JOB_NOT_FOUND: "QUEUE_JOB_NOT_FOUND",
+
   // Encounter date change (packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.ts)
   ENCOUNTER_NOT_FOUND: "ENCOUNTER_NOT_FOUND",
   ENCOUNTER_CHANGE_NOT_FOUND: "ENCOUNTER_CHANGE_NOT_FOUND",

--- a/packages/backend-translate/assets/i18n/en/all.json
+++ b/packages/backend-translate/assets/i18n/en/all.json
@@ -1780,7 +1780,10 @@
           "admin": "Admin",
           "adminSettings": "Admin Settings",
           "copyCompetitions": "Copy Competitions",
-          "adminCompetitions": "Admin Competitions"
+          "adminCompetitions": "Admin Competitions",
+          "dev": "Developer",
+          "devQueue": "Queues",
+          "devLogin": "Developer login"
         },
         "auth": {
           "logIn": "Log in",

--- a/packages/backend-translate/assets/i18n/fr_BE/all.json
+++ b/packages/backend-translate/assets/i18n/fr_BE/all.json
@@ -1842,7 +1842,10 @@
           "admin": "Admin",
           "adminSettings": "Paramètres d'administration",
           "copyCompetitions": "Copier les compétitions",
-          "adminCompetitions": "Admin Compétitions"
+          "adminCompetitions": "Admin Compétitions",
+          "dev": "Développeur",
+          "devQueue": "Files d'attente",
+          "devLogin": "Connexion Développeur"
         },
         "tooltips": {
           "registrationClosed": "Inscriptions fermées"

--- a/packages/backend-translate/assets/i18n/nl_BE/all.json
+++ b/packages/backend-translate/assets/i18n/nl_BE/all.json
@@ -1498,7 +1498,10 @@
           "admin": "Admin",
           "adminSettings": "Admin Instellingen",
           "copyCompetitions": "Competities kopiëren",
-          "adminCompetitions": "Admin Competities"
+          "adminCompetitions": "Admin Competities",
+          "dev": "Ontwikkelaar",
+          "devQueue": "Wachtrijen",
+          "devLogin": "Ontwikkelaar Aanmelding"
         },
         "auth": {
           "logIn": "Inloggen",

--- a/packages/utils/src/lib/i18n.generated.ts
+++ b/packages/utils/src/lib/i18n.generated.ts
@@ -1799,6 +1799,9 @@ export type I18nTranslations = {
                         "adminSettings": string;
                         "copyCompetitions": string;
                         "adminCompetitions": string;
+                        "dev": string;
+                        "devQueue": string;
+                        "devLogin": string;
                     };
                     "auth": {
                         "logIn": string;


### PR DESCRIPTION
Backend half of a developer-only admin panel. The frontend half is [PandaPandaBE/badman-frontend#TBD](https://github.com/PandaPandaBE/badman-frontend) — **this PR needs to merge and deploy first**, because the frontend's `yarn codegen` introspects the live backend and cannot type the new operations until then.

## Why

Triggering a sync is a manual job today: run a mutation by hand, or hit `admin/jobs/*` on the sync worker — a REST controller with **no authentication at all**, which the frontend cannot reach anyway. There is no way to see what the queues are doing from the outside.

## What

### New `QueueResolver` (`packages/backend-graphql/src/resolvers/queue/`)

Ports the worker's `AdminJobsController` onto the API as code-first GraphQL, covering both the `sync` and `ranking` queues. Every operation requires `change:job`.

| Operation | Notes |
|---|---|
| `queueStats: [QueueStats!]!` | Live Redis counters per queue |
| `queueJobs(queue, state, limit): [QueueJob!]!` | `waiting` / `active` / `failed`; queue and state validated against allowlists, `limit` capped at 200 |
| `retryQueueJob(queue, id): QueueJob!` | Only a `failed` job can be retried |

Reads only, so no Sequelize transaction (Constitution III covers DB writes; `retryQueueJob` mutates Redis). Failure modes go through the shared registry rather than inline strings: `BAD_USER_INPUT` for an unknown queue/state, `INVALID_STATE` for a job that is not failed, and a new `QUEUE_JOB_NOT_FOUND`. That last one is a real code rather than a `NotFoundException` because Bull evicts finished jobs on a small window — the job being gone is routine, and a `NotFoundException` surfaces to Apollo as `INTERNAL_SERVER_ERROR`, which clients cannot distinguish from a genuine fault.

### Two fixes in `cronJob.resolver.ts`

- **`cronJobs` was public.** No `@User()`, no permission check — anyone could read the federation sync schedule and job metadata. Now gated on `change:job`, matching the mutations beside it. Nothing consumes the query today, so there is no client to migrate.
- **`updateCronJob` re-registered the crons before committing.** `CronService.onModuleInit()` re-reads the `CronJobs` table, so it could register the *pre-update* schedule. Moved after `commit()` and outside the `try`, so a scheduler failure can no longer call `rollback()` on a durable write.

### `change:job` claim migration

The claim predates migration-based claim seeding, so it exists only as a hand-inserted row on long-lived databases — a fresh database had no way to grant it. The insert is guarded on the name (existing databases already carry it under their own id) and uses category `job` to match production.

### Translations

`all.v1.shell.sidebar.pages.{dev,devQueue,devLogin}` in all three locales, added via the `translation-manager` agent; `i18n.generated.ts` regenerated by booting the API. The frontend's breadcrumbs resolve a label for every registered route, so these are required.

## Testing

`pnpm turbo run lint test --filter=@badman/backend-graphql` — 537 pass, 0 lint errors. New `queue.resolver.spec.ts` follows the Constitution IV pattern (mock Bull queues via `getQueueToken`, fake `Player` with a `hasAnyPermission` stub) and covers each operation's unauthorized path, the field mapping, both validation rejections, and all three retry outcomes. `cronJob.resolver.spec.ts` gains the new auth check plus an assertion that `onModuleInit` runs *after* `commit`.

Also verified live against a local API with real data: counters came back `sync: completed 4, failed 1`, `queueJobs(queue: "sync", state: "failed")` returned an actual failed `EnterScores` job with its `failedReason`, and each error path returned its expected code.

## Reviewer notes

- `retryQueueJob` reports the retried job as `waiting` rather than re-reading its state, which would race with a worker picking it straight up.
- The unauthenticated `AdminJobsController` on the sync worker is left in place; removing it is a separate call.
- Migration is safe to re-run: verified against a database that already had the claim (it skips). Its id collided with an existing claim on a fresh database; fixed below.

## Review fixes (`71b4877`)

Three defects found by a review pass over this branch, all fixed with tests:

- **The claim migration seeded a colliding primary key.** The id it inserted was already the PK of the `change-any:encounter` claim from `20260708000000-add_moving_encounters_setting.js`. On a fresh database the name guard found no `change:job`, the insert hit `Claims_pkey` and aborted `db:migrate` — a deploy-blocking failure. On an existing database `up` skipped correctly, but `down` deleted the *other* claim and cascaded away its role and player grants. Now uses a fresh UUID.
- **`updateCronJob` did not await `onModuleInit()`.** It synchronously deletes every registered cron before re-adding them, so a rejection (e.g. a cron row missing `meta.queueName`) landed after the mutation had already returned success, leaving the scheduler empty — and with no `unhandledRejection` handler in `apps/api`, it could take the process down. Now awaited inside its own `try`/`catch` and logged, so the committed write is still returned and a scheduler failure cannot kill the API. The existing "does not roll back a committed transaction" test only threw synchronously, so a second test covers the async rejection.
- **`queueJobs` returned one job for a non-positive limit.** `Math.max(0, Math.min(limit, 200) - 1)` bottomed out at `0`, and Bull's range is inclusive — so `limit: 0`, an explicit `limit: null`, and negative limits all returned a job. Short-circuits to `[]` before touching the queue.

Also documents `change:job` in [`docs/admin-permissions.md`](docs/admin-permissions.md), which was missing it.

Two notes raised and deliberately left alone, since both are product calls rather than defects: `queueStats` reports `completed`/`delayed` counters that `queueJobs` refuses to list (`BAD_USER_INPUT`), and `retryQueueJob` echoes the pre-retry `attemptsMade`/`failedReason` alongside `state: "waiting"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
